### PR TITLE
Correct documentation of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Requirements
 
 - PHP > 5.3.0
 
-- rackspace/php-cloudfiles.git
+- rackspace/php-opencloud.git
 
 - tvision/RackspaceCloudFilesStreamWrapper
 


### PR DESCRIPTION
I could be wrong, but it seems to me that this bundle doesn't rely on the deprecated php-cloudfiles repo (https://github.com/rackerlabs/php-cloudfiles), rather it uses the new php-opencloud one (https://github.com/rackspace/php-opencloud).
