### PR TITLE
Versions 2.* do not work since 3.0 exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/symfony": "2.*",
-        "tvision/rackspace-cloud-files-streamwrapper": ">=2.2"
+        "tvision/rackspace-cloud-files-streamwrapper": "~2.2"
     }
 
 }


### PR DESCRIPTION
Installing 2.2 or 2.3 causes the installation of the Tvision\RackspaceCloudFilesStreamWrapper v 3.0.\* (due to a poor version constraint in the `composer.json`).

This completely breaks these two versions causing the following fatal error:

``` bash
Fatal error: Class 'Tvision\RackspaceCloudFilesStreamWrapper\Service\RackspaceApi' not found in [...]/app/cache/dev/appDevDebugProjectContainer.php
```

This pull request should fix versions 2.2.\* (branch), but we also need to update the 2.2 and 2.3 tags (being tags I have no idea if there's a way to submit a pull request). I believe the version 2.3 should require the 2.3 version of the stream wrapper library, so things should be updated properly for the two versions. I suggest to use the `~` operator in the composer version constraint and then to delete and recreate the two tags whether possible (or at least to publish two new `2.2.1` and `2.3.1` tags).

In the meanwhile, if someone needs to install the version 2.2 or 2.3, he can use this workaround: force the version of the RackspaceCloudFilesStreamWrapper library in his own `composer.json` file:

example for 2.3.*

``` json
"tvision/rackspace-cloud-files-bundle": "~2.3",
"tvision/rackspace-cloud-files-streamwrapper": "~2.3"
```

Completely wasted almost an hour after a `composer update` before i was able to spot the problem and find a workaround :tired_face:
